### PR TITLE
Using 'img2pdf' instead of imagemagick's 'convert'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@ comicconvert is a simple script that converts any cbr or cbz files to an easy to
 
 All you have to do is run `chmod +x ./comicconvert` from the directory containing the file and then move it to `/usr/local/bin/` to be able to run it from anywhere.
 
-This program was used on a computer running Ubuntu 16.04 and on a windows computers with the windows subsystem for linux. 
+This program was used on a computer running Ubuntu 16.04 and on a windows computers with the windows subsystem for linux.
 
 Reading comics in PDF format is useful when trying to read on devices without the special software for reading cbr or cbz files. This makes it much easier to read comics from various devices
 
 TIP: If you are using the nautilus file manager, place a copy of the script in `~/.local/share/nautilus/scripts` to be able to run comicconvert without using the command line.
 
-NOTE: This program requires  `imagemagick`. you can install it on ubuntu and bash on windows by running `sudo apt-get install imagemagick`.
-
-While converting large comics, you may get some errors associated with low RAM. This is a problem with `imagemagick`. If you have this problem, you can use `img2pdf` from https://github.com/josch/img2pdf instead. img2pdf requires the "-o" option to specify the output file so add that into the code if you're using img2pdf
+This program requires  `img2pdf`. you can install it on ubuntu and bash on windows by running `sudo apt install img2pdf`.

--- a/comicconvert
+++ b/comicconvert
@@ -35,7 +35,7 @@ else
 			unrar e "$rarfile" .cbr/
 
 			find .cbr/ -name "*.webp" -exec dwebp {} -o {}.jpg \;
-			convert .cbr/*.jpg  "$pdffile"
+			img2pdf -o "$pdffile" .cbr/*.jpg
 
 			rm "$rarfile"
 			rm -rf .cbr/
@@ -53,7 +53,7 @@ else
 			unzip -j "$zipfile" -d .cbz/
 
 			find .cbz/ -name "*.webp" -exec dwebp {} -o {}.jpg \;
-			convert .cbz/*.jpg "$pdffile"
+			img2pdf -o "$pdffile" .cbr/*.jpg
 
 			rm "$zipfile"
 			rm -rf .cbz/


### PR DESCRIPTION
As said in the readme, img2pdf doesn't have the low memory problems that convert suffers from.